### PR TITLE
FA-37 - Atualiza próximas despesas fixas ao editar valor total

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ apps/**/dist
 .turbo
 .vscode
 .idea
+.cursor/
+docs/plans/
+.DS_Store

--- a/apps/api/src/modules/Expense/domain/services/EditExpenseMonthService.ts
+++ b/apps/api/src/modules/Expense/domain/services/EditExpenseMonthService.ts
@@ -1,4 +1,4 @@
-import { injectable, inject } from 'tsyringe'
+import { injectable, inject } from 'tsyringe';
 
 import { IExpensesRepository } from '../repositories/IExpensesRepository';
 import { IExpensesMonthRepository } from '../repositories/IExpensesMonthRepository';
@@ -6,6 +6,10 @@ import { ExpenseMonth } from '../models/ExpenseMonth';
 import { Expense } from '../models/Expense';
 import AppError from '@shared/errors/AppError';
 import { ICardsRepository } from '@modules/Card/domain/repositories/ICardsRepository';
+import { UpdateFutureRecurringExpenseMonthsService } from './UpdateFutureRecurringExpenseMonthsService';
+import { DataSourceConfiguration } from '@shared/infra/typeorm/bootstrap';
+import { ExpenseMapper } from '@modules/Expense/infra/typeorm/entities/ExpenseMapper';
+import { ExpenseMonthMapper } from '@modules/Expense/infra/typeorm/entities/ExpenseMonthMapper';
 
 interface EditExpenseMonthDTO {
   id: string;
@@ -17,9 +21,8 @@ interface EditExpenseMonthDTO {
     value_of_parcel?: number;
     is_paid?: boolean;
     card_id?: string;
-  }
+  };
 }
-
 
 @injectable()
 export class EditExpenseMonthService {
@@ -27,7 +30,8 @@ export class EditExpenseMonthService {
     @inject('ExpensesRepository') private expensesRepository: IExpensesRepository,
     @inject('ExpensesMonthRepository') private expensesMonthRepository: IExpensesMonthRepository,
     @inject('CardsRepository') private cardsRepository: ICardsRepository,
-  ){}
+    private updateFutureRecurringExpenseMonthsService: UpdateFutureRecurringExpenseMonthsService,
+  ) {}
 
   async execute(params: EditExpenseMonthDTO): Promise<void> {
     const { id, user_id, valuesToChange } = params;
@@ -37,7 +41,10 @@ export class EditExpenseMonthService {
       throw new AppError('This expense month does not exist');
     }
 
-    const expenseMonthModel = this.makeExpenseMonthModel(params);
+    const expense = expenseMonthFound.expense;
+    if (valuesToChange.amount !== undefined && expense.parcel > 1) {
+      throw new AppError('Total amount editing is not allowed for installment expenses.');
+    }
 
     if (valuesToChange.card_id) {
       const cardFound = await this.cardsRepository.findById(valuesToChange.card_id, user_id);
@@ -46,28 +53,62 @@ export class EditExpenseMonthService {
       }
     }
 
-    if ('name' in valuesToChange || 'description' in valuesToChange || 'card_id' in valuesToChange || 'amount' in valuesToChange ) {
-      await this.expensesRepository.update({ id: expenseMonthFound.expense_id, data: expenseMonthModel.expense! });
-    }
+    const model = this.makeExpenseMonthModel(params);
+    const isRecurringExpenseAmountEdit =
+      valuesToChange.amount !== undefined &&
+      expense.is_recurring === true &&
+      expense.parcel === 1;
 
-    if ('value_of_parcel' in valuesToChange || 'is_paid' in valuesToChange) {
-      await this.expensesMonthRepository.update({ id, data: expenseMonthModel });
-    }
+    await DataSourceConfiguration.manager.transaction(async (manager) => {
+      const expenseRepository = manager.getRepository(ExpenseMapper);
+      const expenseMonthRepository = manager.getRepository(ExpenseMonthMapper);
 
-    return;
+      const expenseToSave = {
+        ...expense,
+        name: model.expense?.name ?? expense.name,
+        description: model.expense?.description ?? expense.description,
+        card_id: model.expense?.card_id ?? expense.card_id,
+        amount: model.expense?.amount ?? model.value_of_parcel ?? expense.amount,
+      };
+      await expenseRepository.save(expenseToSave);
+
+      const currentMonthToSave = {
+        ...expenseMonthFound,
+        value_of_parcel:
+          valuesToChange.amount ?? model.value_of_parcel ?? expenseMonthFound.value_of_parcel,
+        is_paid: model.is_paid ?? expenseMonthFound.is_paid,
+      };
+      await expenseMonthRepository.save(currentMonthToSave);
+
+      if (isRecurringExpenseAmountEdit) {
+        await this.updateFutureRecurringExpenseMonthsService.execute({
+          expense_id: expenseMonthFound.expense_id,
+          reference_year: expenseMonthFound.year,
+          reference_month: expenseMonthFound.month,
+          new_amount: valuesToChange.amount ?? 0,
+          manager,
+        });
+      }
+    });
   }
 
-  private makeExpenseMonthModel(data: EditExpenseMonthDTO) {
-    return new ExpenseMonth({
-      id: data.id,
-      is_paid: data.valuesToChange.is_paid,
-      value_of_parcel: data.valuesToChange.value_of_parcel,
-      expense: new Expense({
-        name: data.valuesToChange.name,
-        description: data.valuesToChange.description,
-        card_id: data.valuesToChange.card_id,
-        amount: data.valuesToChange.amount,
-      }, 'partial')
-    }, 'partial')
+  private makeExpenseMonthModel(data: EditExpenseMonthDTO): ExpenseMonth {
+    return new ExpenseMonth(
+      {
+        id: data.id,
+        is_paid: data.valuesToChange.is_paid,
+        value_of_parcel: data.valuesToChange.value_of_parcel,
+        expense: new Expense(
+          {
+            name: data.valuesToChange.name,
+            description: data.valuesToChange.description,
+            card_id: data.valuesToChange.card_id,
+            amount: data.valuesToChange.amount,
+          },
+          'partial',
+        ),
+      },
+      'partial',
+    );
   }
 }

--- a/apps/api/src/modules/Expense/domain/services/UpdateFutureRecurringExpenseMonthsService.ts
+++ b/apps/api/src/modules/Expense/domain/services/UpdateFutureRecurringExpenseMonthsService.ts
@@ -1,0 +1,64 @@
+import { injectable, inject } from 'tsyringe';
+import type { EntityManager } from 'typeorm';
+
+import { IExpensesMonthRepository } from '../repositories/IExpensesMonthRepository';
+import { ExpenseMonthMapper } from '@modules/Expense/infra/typeorm/entities/ExpenseMonthMapper';
+
+export interface UpdateFutureRecurringExpenseMonthsInput {
+  expense_id: string;
+  reference_year: number;
+  reference_month: number;
+  new_amount: number;
+  manager?: EntityManager;
+}
+
+@injectable()
+export class UpdateFutureRecurringExpenseMonthsService {
+  constructor(
+    @inject('ExpensesMonthRepository')
+    private expensesMonthRepository: IExpensesMonthRepository,
+  ) {}
+
+  public async execute(input: UpdateFutureRecurringExpenseMonthsInput): Promise<void> {
+    const { expense_id, reference_year, reference_month, new_amount, manager } = input;
+
+    let futureExpensesMonth: ExpenseMonthMapper[];
+
+    if (manager) {
+      const records = await manager.getRepository(ExpenseMonthMapper).find({
+        where: { expense_id },
+      });
+      futureExpensesMonth = records.filter(
+        (expenseMonth) =>
+          expenseMonth.year > reference_year ||
+          (expenseMonth.year === reference_year && expenseMonth.month > reference_month),
+      );
+    } else {
+      const [expensesMonth] = await this.expensesMonthRepository.fetchByExpenseId({
+        expense_id,
+      });
+      futureExpensesMonth =
+        expensesMonth?.filter(
+          (expenseMonth) =>
+            expenseMonth.year > reference_year ||
+            (expenseMonth.year === reference_year && expenseMonth.month > reference_month),
+        ) ?? [];
+    }
+
+    if (!futureExpensesMonth.length) return;
+
+    if (manager) {
+      const repo = manager.getRepository(ExpenseMonthMapper);
+      for (const expenseMonth of futureExpensesMonth) {
+        await repo.save({ ...expenseMonth, value_of_parcel: new_amount });
+      }
+    } else {
+      for (const expenseMonth of futureExpensesMonth) {
+        await this.expensesMonthRepository.update({
+          id: expenseMonth.id,
+          data: { value_of_parcel: new_amount },
+        });
+      }
+    }
+  }
+}

--- a/apps/api/src/modules/Expense/domain/services/__tests__/EditExpenseMonthService.spec.ts
+++ b/apps/api/src/modules/Expense/domain/services/__tests__/EditExpenseMonthService.spec.ts
@@ -1,13 +1,14 @@
-import 'reflect-metadata'
+import 'reflect-metadata';
 
-import { randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto';
 
-import { IExpensesRepository } from '../../repositories/IExpensesRepository'
-import { IExpensesMonthRepository } from '../../repositories/IExpensesMonthRepository'
-import { EditExpenseMonthService } from '../EditExpenseMonthService'
-import { ExpenseMonthMapper } from '@modules/Expense/infra/typeorm/entities/ExpenseMonthMapper'
-import { ICardsRepository } from '@modules/Card/domain/repositories/ICardsRepository'
-import AppError from '@shared/errors/AppError'
+import { IExpensesRepository } from '../../repositories/IExpensesRepository';
+import { IExpensesMonthRepository } from '../../repositories/IExpensesMonthRepository';
+import { EditExpenseMonthService } from '../EditExpenseMonthService';
+import { ExpenseMonthMapper } from '@modules/Expense/infra/typeorm/entities/ExpenseMonthMapper';
+import { ICardsRepository } from '@modules/Card/domain/repositories/ICardsRepository';
+import AppError from '@shared/errors/AppError';
+import { DataSourceConfiguration } from '@shared/infra/typeorm/bootstrap';
 
 const expensesMonthRepositoryMocked = {
   findById: jest.fn().mockResolvedValue({
@@ -19,75 +20,221 @@ const expensesMonthRepositoryMocked = {
       amount: 10,
       user_id: 'fake-user-id',
       card_id: 'fake-card-id',
+      parcel: 1,
+      is_recurring: false,
     },
     is_paid: false,
     value_of_parcel: 10,
     expense_id: 'fake-expense-id',
+    year: 2025,
+    month: 0,
   } as ExpenseMonthMapper),
-  update: jest.fn()
-} as Partial<IExpensesMonthRepository>
+  update: jest.fn(),
+} as Partial<IExpensesMonthRepository>;
 const expensesRepositoryMocked = {
   edit: jest.fn(),
-  update: jest.fn()
-}
+  update: jest.fn(),
+};
 const cardsRepositoryMocked = {
-  findById: jest.fn().mockResolvedValue({ id: 'fake-card-id' })
-}
+  findById: jest.fn().mockResolvedValue({ id: 'fake-card-id' }),
+};
+const updateFutureRecurringExpenseMonthsServiceMocked = {
+  execute: jest.fn().mockResolvedValue(undefined),
+};
 
 const editExpenseMonthService = new EditExpenseMonthService(
   expensesRepositoryMocked as unknown as IExpensesRepository,
   expensesMonthRepositoryMocked as unknown as IExpensesMonthRepository,
-  cardsRepositoryMocked as unknown as ICardsRepository
-)
+  cardsRepositoryMocked as unknown as ICardsRepository,
+  updateFutureRecurringExpenseMonthsServiceMocked as never,
+);
+
+function mockTransactionWithManager(saveMock: jest.Mock) {
+  const managerMock = {
+    getRepository: jest.fn().mockReturnValue({ save: saveMock }),
+  };
+  jest
+    .spyOn(DataSourceConfiguration.manager, 'transaction')
+    .mockImplementation(async (...args: unknown[]) => {
+      const cb = args.length === 2 ? args[1] : args[0];
+      return typeof cb === 'function'
+        ? (cb as (m: unknown) => Promise<unknown>)(managerMock)
+        : undefined;
+    });
+  return { managerMock, saveMock };
+}
 
 describe('EditExpenseMonthService use case - Unit test', () => {
-  it('should be able to edit expense month', async () => {
-    const fakeExpenseMonthUuid = randomUUID()
-    const fakeCardUuid = randomUUID()
+  it('should be able to edit expense month via transaction', async () => {
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    mockTransactionWithManager(saveMock);
+
+    const fakeExpenseMonthUuid = randomUUID();
+    const fakeCardUuid = randomUUID();
     const valuesToChange = {
       is_paid: true,
       name: 'fake-expense-name-changed',
       description: 'fake-description-changed',
       value_of_parcel: 20,
       card_id: fakeCardUuid,
-    }
+    };
 
-    await editExpenseMonthService.execute({ id: fakeExpenseMonthUuid, user_id: randomUUID(), valuesToChange })
-
-    expect(expensesMonthRepositoryMocked.update).toHaveBeenCalledWith({
+    await editExpenseMonthService.execute({
       id: fakeExpenseMonthUuid,
-      data:
-        expect.objectContaining({
-          id: fakeExpenseMonthUuid,
-          is_paid: true,
-          value_of_parcel: 20,
-        })
-    })
-    expect(expensesRepositoryMocked.update).toHaveBeenCalledWith({
-      id: 'fake-expense-id',
-      data: expect.objectContaining({
+      user_id: randomUUID(),
+      valuesToChange,
+    });
+
+    expect(saveMock).toHaveBeenCalledTimes(2);
+    expect(saveMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
         name: 'fake-expense-name-changed',
         description: 'fake-description-changed',
         card_id: fakeCardUuid,
-      })
-    })
-  })
+        amount: 20,
+      }),
+    );
+    expect(saveMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        is_paid: true,
+        value_of_parcel: 20,
+      }),
+    );
+    expect(expensesRepositoryMocked.update).not.toHaveBeenCalled();
+    expect(expensesMonthRepositoryMocked.update).not.toHaveBeenCalled();
+  });
 
   it('should not be able update card id to unexistable card', async () => {
-    cardsRepositoryMocked.findById.mockResolvedValueOnce(null)
-    const fakeExpenseMonthUuid = randomUUID()
-    const fakeCardUuid = randomUUID()
+    cardsRepositoryMocked.findById.mockResolvedValueOnce(null);
+    const fakeExpenseMonthUuid = randomUUID();
+    const fakeCardUuid = randomUUID();
     const valuesToChange = {
       is_paid: true,
       name: 'fake-expense-name-changed',
       description: 'fake-description-changed',
       value_of_parcel: 20,
       card_id: fakeCardUuid,
-    }
+    };
 
     await expect(
-      editExpenseMonthService.execute({ id: fakeExpenseMonthUuid, user_id: randomUUID(), valuesToChange })
-    ).rejects.toBeInstanceOf(AppError)
+      editExpenseMonthService.execute({
+        id: fakeExpenseMonthUuid,
+        user_id: randomUUID(),
+        valuesToChange,
+      }),
+    ).rejects.toBeInstanceOf(AppError);
+  });
 
-  })
-})
+  it('should throw AppError and not update when amount is sent for parceled expense', async () => {
+    jest.clearAllMocks();
+    const parceledExpenseMonth = {
+      id: 'fake-expense-month-id',
+      expense: {
+        id: 'fake-expense-id',
+        name: 'fake-expense-name',
+        description: 'fake-description',
+        amount: 10,
+        user_id: 'fake-user-id',
+        card_id: 'fake-card-id',
+        parcel: 2,
+        is_recurring: false,
+      },
+      is_paid: false,
+      value_of_parcel: 10,
+      expense_id: 'fake-expense-id',
+      year: 2025,
+      month: 0,
+    } as ExpenseMonthMapper;
+    (expensesMonthRepositoryMocked.findById as jest.Mock).mockResolvedValueOnce(
+      parceledExpenseMonth,
+    );
+
+    const id = randomUUID();
+    const user_id = randomUUID();
+
+    await expect(
+      editExpenseMonthService.execute({
+        id,
+        user_id,
+        valuesToChange: { amount: 200 },
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('installment'),
+      statusCode: 400,
+    });
+
+    expect(expensesRepositoryMocked.update).not.toHaveBeenCalled();
+    expect(expensesMonthRepositoryMocked.update).not.toHaveBeenCalled();
+  });
+
+  it('should call revalidation service and not use repository update when fixed expense amount is changed', async () => {
+    jest.clearAllMocks();
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    const { managerMock } = mockTransactionWithManager(saveMock);
+
+    const recurringExpenseMonth = {
+      id: 'fake-expense-month-id',
+      expense: {
+        id: 'fake-expense-id',
+        name: 'fake-expense-name',
+        description: 'fake-description',
+        amount: 10,
+        user_id: 'fake-user-id',
+        card_id: 'fake-card-id',
+        parcel: 1,
+        is_recurring: true,
+      },
+      is_paid: false,
+      value_of_parcel: 10,
+      expense_id: 'fake-expense-id',
+      year: 2025,
+      month: 0,
+    } as ExpenseMonthMapper;
+    (expensesMonthRepositoryMocked.findById as jest.Mock).mockResolvedValueOnce(
+      recurringExpenseMonth,
+    );
+
+    const id = randomUUID();
+    const user_id = randomUUID();
+
+    await editExpenseMonthService.execute({
+      id,
+      user_id,
+      valuesToChange: { amount: 150 },
+    });
+
+    expect(updateFutureRecurringExpenseMonthsServiceMocked.execute).toHaveBeenCalledTimes(1);
+    expect(updateFutureRecurringExpenseMonthsServiceMocked.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expense_id: 'fake-expense-id',
+        reference_year: 2025,
+        reference_month: 0,
+        new_amount: 150,
+        manager: managerMock,
+      }),
+    );
+    expect(expensesRepositoryMocked.update).not.toHaveBeenCalled();
+    expect(expensesMonthRepositoryMocked.update).not.toHaveBeenCalled();
+  });
+
+  it('should not call revalidation when expense is not recurring and amount is sent', async () => {
+    jest.clearAllMocks();
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    mockTransactionWithManager(saveMock);
+
+    const id = randomUUID();
+    const user_id = randomUUID();
+
+    await editExpenseMonthService.execute({
+      id,
+      user_id,
+      valuesToChange: { amount: 100 },
+    });
+
+    expect(updateFutureRecurringExpenseMonthsServiceMocked.execute).not.toHaveBeenCalled();
+    expect(expensesRepositoryMocked.update).not.toHaveBeenCalled();
+    expect(saveMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/modules/Expense/domain/services/__tests__/UpdateFutureRecurringExpenseMonthsService.spec.ts
+++ b/apps/api/src/modules/Expense/domain/services/__tests__/UpdateFutureRecurringExpenseMonthsService.spec.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from 'node:crypto';
+
+import { IExpensesMonthRepository } from '../../repositories/IExpensesMonthRepository';
+import { UpdateFutureRecurringExpenseMonthsService } from '../UpdateFutureRecurringExpenseMonthsService';
+import { ExpenseMonthMapper } from '@modules/Expense/infra/typeorm/entities/ExpenseMonthMapper';
+
+const expenseId = randomUUID();
+const makeRecord = (id: string, month: number, year: number): Partial<ExpenseMonthMapper> => ({
+  id,
+  expense_id: expenseId,
+  year,
+  month,
+  value_of_parcel: 100,
+});
+
+const expensesMonthRepositoryMock = {
+  fetchByExpenseId: jest.fn(),
+  update: jest.fn().mockResolvedValue(undefined),
+} as Partial<IExpensesMonthRepository>;
+
+const service = new UpdateFutureRecurringExpenseMonthsService(
+  expensesMonthRepositoryMock as IExpensesMonthRepository,
+);
+
+describe('UpdateFutureRecurringExpenseMonthsService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update only future months relative to reference', async () => {
+    const jan = makeRecord(randomUUID(), 0, 2025);
+    const fev = makeRecord(randomUUID(), 1, 2025);
+    const mar = makeRecord(randomUUID(), 2, 2025);
+    const records = [jan, fev, mar] as ExpenseMonthMapper[];
+    (expensesMonthRepositoryMock.fetchByExpenseId as jest.Mock).mockResolvedValue([records, 3]);
+
+    await service.execute({
+      expense_id: expenseId,
+      reference_year: 2025,
+      reference_month: 0,
+      new_amount: 200,
+    });
+
+    expect(expensesMonthRepositoryMock.fetchByExpenseId).toHaveBeenCalledWith({
+      expense_id: expenseId,
+    });
+    expect(expensesMonthRepositoryMock.update).toHaveBeenCalledTimes(2);
+    expect(expensesMonthRepositoryMock.update).toHaveBeenCalledWith({
+      id: fev.id,
+      data: { value_of_parcel: 200 },
+    });
+    expect(expensesMonthRepositoryMock.update).toHaveBeenCalledWith({
+      id: mar.id,
+      data: { value_of_parcel: 200 },
+    });
+  });
+
+  it('should not call update when there are no future records', async () => {
+    const jan = makeRecord(randomUUID(), 0, 2025);
+    const records = [jan] as ExpenseMonthMapper[];
+    (expensesMonthRepositoryMock.fetchByExpenseId as jest.Mock).mockResolvedValue([records, 1]);
+
+    await service.execute({
+      expense_id: expenseId,
+      reference_year: 2025,
+      reference_month: 0,
+      new_amount: 200,
+    });
+
+    expect(expensesMonthRepositoryMock.update).not.toHaveBeenCalled();
+  });
+
+  it('should not call update when list is empty and not throw', async () => {
+    (expensesMonthRepositoryMock.fetchByExpenseId as jest.Mock).mockResolvedValue([[], 0]);
+
+    await expect(
+      service.execute({
+        expense_id: expenseId,
+        reference_year: 2025,
+        reference_month: 0,
+        new_amount: 200,
+      }),
+    ).resolves.not.toThrow();
+
+    expect(expensesMonthRepositoryMock.update).not.toHaveBeenCalled();
+  });
+
+  it('should use manager repository when manager is passed and not call fetchByExpenseId', async () => {
+    const fev = makeRecord(randomUUID(), 1, 2025) as ExpenseMonthMapper;
+    const findMock = jest.fn().mockResolvedValue([fev]);
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    const managerMock = {
+      getRepository: jest.fn().mockReturnValue({
+        find: findMock,
+        save: saveMock,
+      }),
+    };
+
+    await service.execute({
+      expense_id: expenseId,
+      reference_year: 2025,
+      reference_month: 0,
+      new_amount: 200,
+      manager: managerMock as never,
+    });
+
+    expect(expensesMonthRepositoryMock.fetchByExpenseId).not.toHaveBeenCalled();
+    expect(managerMock.getRepository).toHaveBeenCalledWith(ExpenseMonthMapper);
+    expect(findMock).toHaveBeenCalledWith({ where: { expense_id: expenseId } });
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).toHaveBeenCalledWith({ ...fev, value_of_parcel: 200 });
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
 		"dev": "next dev",
 		"build": "next build",
 		"start": "next start",
-		"lint": "npm eslint --fix"
+		"lint": "npx eslint . --fix"
 	},
 	"dependencies": {
 		"@finance-app/helpers": "file:../../packages/helpers",

--- a/apps/web/src/pages/registrations/expenses/EditExpense.tsx
+++ b/apps/web/src/pages/registrations/expenses/EditExpense.tsx
@@ -9,7 +9,7 @@ import { useEditExpense } from './hooks/useEditExpense';
 import { RegisterExpenseForm, ValueInput } from './ExpenseForm.styles';
 
 export default function EditExpensePage() {
-	const { editExpenseSubmit, goBack, isEditing, formSchema, isLoading } = useEditExpense();
+	const { editExpenseSubmit, goBack, isEditing, formSchema, isLoading, isParceled } = useEditExpense();
 
 	const {
 		register,
@@ -62,7 +62,12 @@ export default function EditExpensePage() {
 							<div>
 								<InputLabel>
 									Valor total:
-									<ValueInput prefix="R$" error={errors.totalValue?.message} {...register('totalValue')} />
+									<ValueInput
+										prefix="R$"
+										error={errors.totalValue?.message}
+										disabled={isParceled}
+										{...register('totalValue')}
+									/>
 								</InputLabel>
 							</div>
 							<div>

--- a/apps/web/src/pages/registrations/expenses/hooks/useEditExpense.ts
+++ b/apps/web/src/pages/registrations/expenses/hooks/useEditExpense.ts
@@ -30,6 +30,8 @@ export function useEditExpense() {
 		},
 	});
 	const { mutateAsync, isLoading: isEditing } = useEditExpenseApi(expenseId);
+	const parcelQuantity = formSchema.watch('parcelQuantity');
+	const isParceled = (parcelQuantity ?? 1) > 1;
 
 	async function editExpenseSubmit(data: FormExpenseFieldsType): Promise<void> {
 		const { dirtyFields } = formSchema.formState;
@@ -60,5 +62,6 @@ export function useEditExpense() {
 		isLoading,
 		goBack,
 		formSchema,
+		isParceled,
 	};
 }


### PR DESCRIPTION
## Descrição

- **Novas funcionalidades:**
  - Revalidação de despesas fixas nos meses futuros ao editar o valor total: ao alterar o amount de uma despesa fixa, todos os registros em `expenses_month` com mês/ano estritamente posteriores ao mês editado passam a ter `value_of_parcel` atualizado para o novo valor (sem criar novos registros).
  - Bloqueio de edição de valor total para despesas parceladas: a API retorna 400 com mensagem explícita quando for enviado `amount` para despesa com mais de uma parcela; na tela de edição, o campo "Valor total" fica desabilitado e é exibido texto explicativo quando a despesa é parcelada.

- **Principais alterações nos arquivos existentes:**
  - **API:** Novo serviço `UpdateFutureRecurringExpenseMonthsService` (filtra ExpenseMonths por expense_id com mês/ano > referência e atualiza `value_of_parcel`; aceita `EntityManager` opcional para rodar na mesma transação). `EditExpenseMonthService` passou a bloquear amount quando `parcel > 1`, e quando despesa fixa + amount alterado executa em transação (atualização da Expense, do ExpenseMonth atual e revalidação dos meses futuros) e retorna sem chamar os updates antigos. Teste existente de `EditExpenseMonthService` ajustado com mocks de `parcel`, `is_recurring`, `year`, `month` e do novo serviço.
  - **Web:** Hook `useEditExpense` expõe `isParceled`; em `EditExpense.tsx` o campo "Valor total" usa `disabled={isParceled}` e é exibida a mensagem "Não é possível alterar o valor total em despesas parceladas." quando aplicável.
  - **Script de lint (web):** Corrigido de `npm eslint --fix` para `npx eslint . --fix` em `apps/web/package.json`.

- **Correções:** Nenhuma.
