### PR TITLE
FA-38 - Adicionar atalho para realizar submit e alterar ordem de foco pelo Tab

### DIFF
--- a/apps/web/src/pages/registrations/expenses/CreateExpense.tsx
+++ b/apps/web/src/pages/registrations/expenses/CreateExpense.tsx
@@ -8,15 +8,16 @@ import { PaymentMethodSelectionSection } from './components/PaymentMethodSelecti
 import { ShareExpenseSection } from './components/ShareExpenseSection';
 import { CREATE_EXPENSE_TAB_ORDER } from './constants/tabOrder';
 import { useCreateExpense } from './hooks/useCreateExpense';
-import { RegisterExpenseForm, ValueInput } from './ExpenseForm.styles';
+import { RegisterExpenseForm, SubmitShortcutHint, ValueInput } from './ExpenseForm.styles';
 
 const CREATE_EXPENSE_FORM_ID = 'create-expense-form';
 
 export default function CreateExpensePage() {
-	const { onSubmitCreateExpense, isCreatingExpense, formSchema, submitShortcutLabel } = useCreateExpense();
+	const { createExpenseSubmit, isCreatingExpense, formSchema, submitShortcutLabel } = useCreateExpense();
 
 	const {
 		register,
+		handleSubmit,
 		formState: { errors },
 		reset,
 		watch,
@@ -33,13 +34,7 @@ export default function CreateExpensePage() {
 					<LayoutBox.HeaderTitle>Adicionar despesa</LayoutBox.HeaderTitle>
 				</LayoutBox.Header>
 				<LayoutBox.Content>
-					<RegisterExpenseForm
-						id={CREATE_EXPENSE_FORM_ID}
-						onSubmit={event => {
-							event.preventDefault();
-							onSubmitCreateExpense();
-						}}
-					>
+					<RegisterExpenseForm id={CREATE_EXPENSE_FORM_ID} onSubmit={handleSubmit(createExpenseSubmit)}>
 						<Flex>
 							<InputLabel>
 								Nome:
@@ -126,7 +121,7 @@ export default function CreateExpensePage() {
 								title={`Atalho: ${submitShortcutLabel}`}
 								spinnerConfig={{ mode: 'light', size: 'sm' }}
 							>
-								Criar despesa ({submitShortcutLabel})
+								Criar despesa <SubmitShortcutHint>({submitShortcutLabel})</SubmitShortcutHint>
 							</ActionButtons.Submit>
 						</ActionButtons>
 					</LayoutBox.FooterRightSide>

--- a/apps/web/src/pages/registrations/expenses/CreateExpense.tsx
+++ b/apps/web/src/pages/registrations/expenses/CreateExpense.tsx
@@ -6,15 +6,17 @@ import { TextInput, InputLabel, ActionButtons, Switch } from '@/components/Form'
 
 import { PaymentMethodSelectionSection } from './components/PaymentMethodSelection';
 import { ShareExpenseSection } from './components/ShareExpenseSection';
+import { CREATE_EXPENSE_TAB_ORDER } from './constants/tabOrder';
 import { useCreateExpense } from './hooks/useCreateExpense';
 import { RegisterExpenseForm, ValueInput } from './ExpenseForm.styles';
 
+const CREATE_EXPENSE_FORM_ID = 'create-expense-form';
+
 export default function CreateExpensePage() {
-	const { createExpenseSubmit, isCreatingExpense, formSchema } = useCreateExpense();
+	const { onSubmitCreateExpense, isCreatingExpense, formSchema, submitShortcutLabel } = useCreateExpense();
 
 	const {
 		register,
-		handleSubmit,
 		formState: { errors },
 		reset,
 		watch,
@@ -31,13 +33,20 @@ export default function CreateExpensePage() {
 					<LayoutBox.HeaderTitle>Adicionar despesa</LayoutBox.HeaderTitle>
 				</LayoutBox.Header>
 				<LayoutBox.Content>
-					<RegisterExpenseForm>
+					<RegisterExpenseForm
+						id={CREATE_EXPENSE_FORM_ID}
+						onSubmit={event => {
+							event.preventDefault();
+							onSubmitCreateExpense();
+						}}
+					>
 						<Flex>
 							<InputLabel>
 								Nome:
 								<TextInput
 									placeholder="Insira o nome de sua despesa aqui"
 									error={errors.name?.message}
+									tabIndex={CREATE_EXPENSE_TAB_ORDER.name}
 									{...register('name')}
 								/>
 							</InputLabel>
@@ -53,6 +62,7 @@ export default function CreateExpensePage() {
 										prefix="R$"
 										error={errors.totalValue?.message}
 										disabled={isSplit}
+										tabIndex={CREATE_EXPENSE_TAB_ORDER.totalValue}
 										{...register('totalValue')}
 									/>
 								</InputLabel>
@@ -63,6 +73,7 @@ export default function CreateExpensePage() {
 									<ValueInput
 										error={errors.parcelQuantity?.message}
 										disabled={isSplit}
+										tabIndex={CREATE_EXPENSE_TAB_ORDER.parcelQuantity}
 										{...register('parcelQuantity', {
 											valueAsNumber: true,
 										})}
@@ -72,14 +83,16 @@ export default function CreateExpensePage() {
 							<div>
 								<InputLabel>
 									Valor por parcela:
-									<ValueInput prefix="R$" disabled {...register('parcelValue')} />
+									<ValueInput prefix="R$" disabled tabIndex={-1} {...register('parcelValue')} />
 								</InputLabel>
 							</div>
 							<Flex flexDirection="column" gap="0.5rem" whiteSpace="nowrap">
 								<InputLabel>Despesa fixa:</InputLabel>
 								<Controller
 									name="isRecurring"
-									render={({ field: { value, ...field } }) => <Switch checked={value} {...field} />}
+									render={({ field: { value, ...field } }) => (
+										<Switch checked={value} tabIndex={CREATE_EXPENSE_TAB_ORDER.isRecurring} {...field} />
+									)}
 								/>
 							</Flex>
 							<Flex flexDirection="column" gap="0.5rem" whiteSpace="nowrap">
@@ -87,7 +100,13 @@ export default function CreateExpensePage() {
 								<Controller
 									name="isSplit"
 									render={({ field: { value, ...field } }) => (
-										<Switch id="isSplit" isDisabled={isExpenseAmountNonFilled} checked={value} {...field} />
+										<Switch
+											id="isSplit"
+											isDisabled={isExpenseAmountNonFilled}
+											checked={value}
+											tabIndex={CREATE_EXPENSE_TAB_ORDER.isSplit}
+											{...field}
+										/>
 									)}
 								/>
 							</Flex>
@@ -98,13 +117,16 @@ export default function CreateExpensePage() {
 				<LayoutBox.Footer>
 					<LayoutBox.FooterRightSide>
 						<ActionButtons>
-							<ActionButtons.Cancel onClick={() => reset()} />
+							<ActionButtons.Cancel tabIndex={CREATE_EXPENSE_TAB_ORDER.cancel} onClick={() => reset()} />
 							<ActionButtons.Submit
-								onClick={handleSubmit(createExpenseSubmit)}
+								form={CREATE_EXPENSE_FORM_ID}
 								isLoading={isCreatingExpense}
+								tabIndex={CREATE_EXPENSE_TAB_ORDER.submit}
+								aria-keyshortcuts="Control+Enter Meta+Enter"
+								title={`Atalho: ${submitShortcutLabel}`}
 								spinnerConfig={{ mode: 'light', size: 'sm' }}
 							>
-								Criar despesa
+								Criar despesa ({submitShortcutLabel})
 							</ActionButtons.Submit>
 						</ActionButtons>
 					</LayoutBox.FooterRightSide>

--- a/apps/web/src/pages/registrations/expenses/ExpenseForm.styles.ts
+++ b/apps/web/src/pages/registrations/expenses/ExpenseForm.styles.ts
@@ -12,3 +12,9 @@ export const RegisterExpenseForm = styled.form`
 export const ValueInput = styled(TextInput)`
 	width: 136px;
 `;
+
+export const SubmitShortcutHint = styled.span`
+	font-size: ${({ theme }) => theme.fontSizes.xs};
+	font-weight: 400;
+	opacity: 0.85;
+`;

--- a/apps/web/src/pages/registrations/expenses/components/PaymentMethodSelection/PaymentMethodSelection.tsx
+++ b/apps/web/src/pages/registrations/expenses/components/PaymentMethodSelection/PaymentMethodSelection.tsx
@@ -9,6 +9,7 @@ import { FieldDescription } from './PaymentMethodSelection.styles';
 import { useListCardsApi } from '@/hooks/api/cards/useListCards.api';
 
 import { FormExpenseFieldsType } from '../../constants/formSchema';
+import { CREATE_EXPENSE_TAB_ORDER } from '../../constants/tabOrder';
 
 interface PaymentMethodSelectionSectionProps {
 	isEditMode?: boolean;
@@ -33,12 +34,23 @@ export default function PaymentMethodSelectionSection({ isEditMode }: PaymentMet
 		<Grid gridTemplateColumns={isEditMode ? '200px 1fr' : '200px 418px 1fr'} margin="0.5rem 0 0 0" gap="1.5rem">
 			<InputLabel>
 				Data de compra:
-				<TextInput type="date" max={maxDateLimit} {...register('purchaseDate')} disabled={isEditMode} />
+				<TextInput
+					type="date"
+					max={maxDateLimit}
+					tabIndex={isEditMode ? undefined : CREATE_EXPENSE_TAB_ORDER.purchaseDate}
+					{...register('purchaseDate')}
+					disabled={isEditMode}
+				/>
 			</InputLabel>
 			{!isEditMode && (
 				<InputLabel>
 					Data da despesa:
-					<TextInput type="month" {...register('manualExpenseDate')} disabled={isEditMode} />
+					<TextInput
+						type="month"
+						tabIndex={CREATE_EXPENSE_TAB_ORDER.manualExpenseDate}
+						{...register('manualExpenseDate')}
+						disabled={isEditMode}
+					/>
 				</InputLabel>
 			)}
 			<InputLabel>
@@ -54,6 +66,7 @@ export default function PaymentMethodSelectionSection({ isEditMode }: PaymentMet
 								placeholder="Selecione o meio de pagamento"
 								options={paymentMethodsOptions ?? []}
 								{...field}
+								tabIndex={isEditMode ? undefined : CREATE_EXPENSE_TAB_ORDER.paymentMethod}
 							/>
 						)}
 					/>

--- a/apps/web/src/pages/registrations/expenses/components/ShareExpenseSection/ShareExpenseSection.tsx
+++ b/apps/web/src/pages/registrations/expenses/components/ShareExpenseSection/ShareExpenseSection.tsx
@@ -6,6 +6,7 @@ import { ArrowSquareOut as ArrowSquareOutIcon, Trash as TrashIcon } from 'phosph
 
 import { Flex, Grid, InputLabel, Select, Divider, TextInput, Button, Currency, Text } from '@/components';
 import { FormExpenseFieldsType } from '../../constants/formSchema';
+import { CREATE_EXPENSE_TAB_ORDER } from '../../constants/tabOrder';
 import { FieldDescription } from '../PaymentMethodSelection/PaymentMethodSelection.styles';
 import { sharePeopleExpenseSchema, type ShareExpenseFormFields } from './constants/formSchema';
 import { useFetchSharePeopleApi } from '@/hooks/api/sharePeople/useFetchSharePeople.api';
@@ -94,6 +95,7 @@ export function ShareExpenseSection() {
 											options={sharePeopleOptions || []}
 											isLoading={isLoadingSharePeople}
 											{...field}
+											tabIndex={CREATE_EXPENSE_TAB_ORDER.sharePerson}
 										/>
 									)}
 								/>
@@ -116,6 +118,7 @@ export function ShareExpenseSection() {
 									type="number"
 									step="0.01"
 									error={errors.amount?.message}
+									tabIndex={CREATE_EXPENSE_TAB_ORDER.shareAmount}
 									{...register('amount')}
 								/>
 								<FieldDescription>
@@ -131,6 +134,7 @@ export function ShareExpenseSection() {
 						variant="outline"
 						onClick={handleSubmit(handleAddSharePerson)}
 						isDisabled={!isValid}
+						tabIndex={CREATE_EXPENSE_TAB_ORDER.shareAdd}
 					>
 						Adicionar
 					</Button>

--- a/apps/web/src/pages/registrations/expenses/constants/tabOrder.ts
+++ b/apps/web/src/pages/registrations/expenses/constants/tabOrder.ts
@@ -1,0 +1,19 @@
+/**
+ * Tab order optimized for repeated expense entry:
+ * name → value fields first; preserved fields (dates, card) last.
+ */
+export const CREATE_EXPENSE_TAB_ORDER = {
+	name: 1,
+	totalValue: 2,
+	parcelQuantity: 3,
+	isRecurring: 4,
+	isSplit: 5,
+	sharePerson: 6,
+	shareAmount: 7,
+	shareAdd: 8,
+	purchaseDate: 9,
+	manualExpenseDate: 10,
+	paymentMethod: 11,
+	cancel: 12,
+	submit: 13,
+} as const;

--- a/apps/web/src/pages/registrations/expenses/helpers/isSubmitShortcut.ts
+++ b/apps/web/src/pages/registrations/expenses/helpers/isSubmitShortcut.ts
@@ -1,0 +1,13 @@
+export function isSubmitShortcut(event: KeyboardEvent): boolean {
+	return (event.ctrlKey || event.metaKey) && event.key === 'Enter';
+}
+
+export function getSubmitShortcutLabel(): string {
+	if (typeof navigator === 'undefined') {
+		return 'Ctrl+Enter';
+	}
+
+	const isAppleDevice = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+
+	return isAppleDevice ? '⌘+Enter' : 'Ctrl+Enter';
+}

--- a/apps/web/src/pages/registrations/expenses/hooks/useCreateExpense.ts
+++ b/apps/web/src/pages/registrations/expenses/hooks/useCreateExpense.ts
@@ -1,10 +1,11 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import { getMonth, getYear } from 'date-fns';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 
 import { FormExpenseFieldsType, createFormExpenseFormSchema } from '../constants/formSchema';
+import { getSubmitShortcutLabel, isSubmitShortcut } from '../helpers/isSubmitShortcut';
 import { useCreateExpenseApi } from '@/hooks/api/expenses/useCreateExpense.api';
 
 export function useCreateExpense() {
@@ -18,6 +19,8 @@ export function useCreateExpense() {
 		},
 	});
 	const { mutate, isLoading: isCreating } = useCreateExpenseApi();
+	const { handleSubmit, resetField, setFocus, setValue, watch } = formSchema;
+	const [submitShortcutLabel, setSubmitShortcutLabel] = useState('Ctrl+Enter');
 
 	const calculateParcelValue = useCallback((value: number, parcels: number) => {
 		if (!value || !parcels) return 0;
@@ -25,51 +28,81 @@ export function useCreateExpense() {
 		return Number((value / parcels).toFixed(2));
 	}, []);
 
-	async function createExpenseSubmit(data: FormExpenseFieldsType): Promise<void> {
-		mutate(
-			{
-				name: data.name,
-				amount: data.totalValue!,
-				cardId: data.paymentMethod.value,
-				parcel: data.parcelQuantity,
-				isRecurring: data.isRecurring,
-				purchaseDate: data.purchaseDate,
-				manualExpenseDate: data.manualExpenseDate!,
-				sharePeopleExpense: data.sharePeopleExpense,
-			},
-			{
-				onSuccess: () => {
-					toast.success('Despesa criada com sucesso!');
-					formSchema.resetField('name');
-					formSchema.resetField('category');
-					formSchema.resetField('totalValue');
-					formSchema.resetField('isRecurring');
-					formSchema.resetField('parcelQuantity');
-					formSchema.resetField('parcelValue');
-					formSchema.resetField('isSplit', { defaultValue: false });
-					formSchema.resetField('sharePeopleExpense');
-					formSchema.setFocus('name');
+	const createExpenseSubmit = useCallback(
+		async (data: FormExpenseFieldsType): Promise<void> => {
+			mutate(
+				{
+					name: data.name,
+					amount: data.totalValue!,
+					cardId: data.paymentMethod.value,
+					parcel: data.parcelQuantity,
+					isRecurring: data.isRecurring,
+					purchaseDate: data.purchaseDate,
+					manualExpenseDate: data.manualExpenseDate!,
+					sharePeopleExpense: data.sharePeopleExpense,
 				},
-			},
-		);
-	}
+				{
+					onSuccess: () => {
+						toast.success('Despesa criada com sucesso!');
+						resetField('name');
+						resetField('category');
+						resetField('totalValue');
+						resetField('isRecurring');
+						resetField('parcelQuantity');
+						resetField('parcelValue');
+						resetField('isSplit', { defaultValue: false });
+						resetField('sharePeopleExpense');
+						setFocus('name');
+					},
+				},
+			);
+		},
+		[mutate, resetField, setFocus],
+	);
 
-	const totalValue = formSchema.watch('totalValue');
+	const onSubmitCreateExpense = useCallback(() => {
+		if (isCreating) return;
+
+		void handleSubmit(createExpenseSubmit)();
+	}, [createExpenseSubmit, handleSubmit, isCreating]);
+
+	useEffect(() => {
+		setSubmitShortcutLabel(getSubmitShortcutLabel());
+	}, []);
+
+	useEffect(() => {
+		function handleKeyDown(event: KeyboardEvent) {
+			if (!isSubmitShortcut(event)) return;
+
+			event.preventDefault();
+			onSubmitCreateExpense();
+		}
+
+		document.addEventListener('keydown', handleKeyDown);
+
+		return () => {
+			document.removeEventListener('keydown', handleKeyDown);
+		};
+	}, [onSubmitCreateExpense]);
+
+	const totalValue = watch('totalValue');
 	const parcelValue =
 		calculateParcelValue(
 			Number(totalValue) || Number(String(totalValue)?.replace(',', '.')),
-			formSchema.watch('parcelQuantity'),
+			watch('parcelQuantity'),
 		) ?? 0;
 
 	useEffect(() => {
 		if (parcelValue) {
-			formSchema.setValue('parcelValue', parcelValue);
+			setValue('parcelValue', parcelValue);
 		}
-	}, [parcelValue]);
+	}, [parcelValue, setValue]);
 
 	return {
 		createExpenseSubmit,
+		onSubmitCreateExpense,
 		isCreatingExpense: isCreating,
 		formSchema,
+		submitShortcutLabel,
 	};
 }

--- a/apps/web/src/pages/registrations/expenses/hooks/useCreateExpense.ts
+++ b/apps/web/src/pages/registrations/expenses/hooks/useCreateExpense.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { toast } from 'react-toastify';
 import { getMonth, getYear } from 'date-fns';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -20,7 +20,6 @@ export function useCreateExpense() {
 	});
 	const { mutate, isLoading: isCreating } = useCreateExpenseApi();
 	const { handleSubmit, resetField, setFocus, setValue, watch } = formSchema;
-	const [submitShortcutLabel, setSubmitShortcutLabel] = useState('Ctrl+Enter');
 
 	const calculateParcelValue = useCallback((value: number, parcels: number) => {
 		if (!value || !parcels) return 0;
@@ -60,22 +59,16 @@ export function useCreateExpense() {
 		[mutate, resetField, setFocus],
 	);
 
-	const onSubmitCreateExpense = useCallback(() => {
-		if (isCreating) return;
-
-		void handleSubmit(createExpenseSubmit)();
-	}, [createExpenseSubmit, handleSubmit, isCreating]);
-
-	useEffect(() => {
-		setSubmitShortcutLabel(getSubmitShortcutLabel());
-	}, []);
-
+	/**
+	 * Registra o atalho Ctrl/Cmd+Enter para submeter o formulário sem clicar no botão.
+	 * Ignora o atalho enquanto uma requisição de criação já estiver em andamento.
+	 */
 	useEffect(() => {
 		function handleKeyDown(event: KeyboardEvent) {
-			if (!isSubmitShortcut(event)) return;
+			if (!isSubmitShortcut(event) || isCreating) return;
 
 			event.preventDefault();
-			onSubmitCreateExpense();
+			void handleSubmit(createExpenseSubmit)();
 		}
 
 		document.addEventListener('keydown', handleKeyDown);
@@ -83,7 +76,7 @@ export function useCreateExpense() {
 		return () => {
 			document.removeEventListener('keydown', handleKeyDown);
 		};
-	}, [onSubmitCreateExpense]);
+	}, [createExpenseSubmit, handleSubmit, isCreating]);
 
 	const totalValue = watch('totalValue');
 	const parcelValue =
@@ -92,6 +85,9 @@ export function useCreateExpense() {
 			watch('parcelQuantity'),
 		) ?? 0;
 
+	/**
+	 * Mantém o valor por parcela sincronizado quando o valor total ou a quantidade de parcelas mudam.
+	 */
 	useEffect(() => {
 		if (parcelValue) {
 			setValue('parcelValue', parcelValue);
@@ -100,9 +96,8 @@ export function useCreateExpense() {
 
 	return {
 		createExpenseSubmit,
-		onSubmitCreateExpense,
 		isCreatingExpense: isCreating,
 		formSchema,
-		submitShortcutLabel,
+		submitShortcutLabel: getSubmitShortcutLabel(),
 	};
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Melhora a usabilidade do formulário de criação de despesas para cadastros em sequência.

- Atalho **Ctrl+Enter** (Windows/Linux) / **⌘+Enter** (Mac) para submeter o formulário sem clicar no botão
- Ordem de Tab otimizada: após o campo **Nome**, o próximo foco vai para **Valor total**
- Campos preservados após o primeiro cadastro (**data de compra**, **data da despesa**, **meio de pagamento**) ficam por último na navegação por Tab
- O botão de submit exibe o atalho em tamanho menor ao lado do texto principal

## Tab order
1. Nome → Valor total → Parcelas → Despesa fixa → Compartilhar
2. (se split) pessoa / valor / adicionar
3. Data de compra → Data da despesa → Meio de pagamento
4. Cancelar → Criar despesa

## Test plan
- [x] Abrir `/registrations/expenses` e preencher nome; Tab deve ir para valor total
- [x] Continuar Tab e confirmar que datas e cartão vêm depois dos campos de valor/switches
- [x] Criar uma despesa e confirmar que nome/valor são limpos e cartão/datas permanecem
- [x] Usar Ctrl+Enter (ou ⌘+Enter) para criar outra despesa
- [x] Confirmar que o atalho no botão aparece menor que o texto "Criar despesa"

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9c70-e7a8-7cee-94cb-18d4b96dc507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9c70-e7a8-7cee-94cb-18d4b96dc507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

