### PR TITLE
FA-39 - Corrigir validação de purchase_date no schema Zod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: CI Pipeline
       - opened
       - synchronize
       - reopened
+      - ready_for_review
     branches:
       - master
 jobs:

--- a/apps/api/src/modules/Expense/domain/models/Expense.ts
+++ b/apps/api/src/modules/Expense/domain/models/Expense.ts
@@ -8,7 +8,10 @@ export class Expense {
     parcel: z.number().positive(),
     card_id: z.string().uuid(),
     user_id: z.string().uuid(),
-    purchase_date: z.coerce.date().max(new Date()),
+    purchase_date: z.coerce.date().refine(
+      (date) => date <= new Date(),
+      { message: 'A data de compra deve ser menor ou igual a hoje' },
+    ),
     is_recurring: z.boolean(),
     due_date: z.coerce.date().optional().nullable(),
     description: z.string().max(120).optional().nullable(),

--- a/apps/api/src/modules/Expense/domain/models/__tests__/Expense.spec.ts
+++ b/apps/api/src/modules/Expense/domain/models/__tests__/Expense.spec.ts
@@ -72,4 +72,62 @@ describe('Expense model - Unit test', () => {
       expect(error).toBeInstanceOf(ZodError);
     }
   });
+
+  it('should accept purchase_date up to today even after the process has aged', async () => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-26T12:00:00.000Z'));
+
+    const { Expense: ExpenseModel } = await import('../Expense');
+
+    jest.setSystemTime(new Date('2026-08-01T12:00:00.000Z'));
+
+    expect(
+      () =>
+        new ExpenseModel(
+          {
+            name: 'fake-card-name',
+            amount: 100,
+            parcel: 1,
+            card_id: v4(),
+            user_id: v4(),
+            purchase_date: '2026-07-28',
+            is_recurring: false,
+            is_splitted: false,
+          },
+          'create',
+        ),
+    ).not.toThrow();
+
+    jest.useRealTimers();
+  });
+
+  it('should reject purchase_date greater than today', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-01T12:00:00.000Z'));
+
+    try {
+      new Expense(
+        {
+          name: 'fake-card-name',
+          amount: 100,
+          parcel: 1,
+          card_id: v4(),
+          user_id: v4(),
+          purchase_date: '2026-08-02',
+          is_recurring: false,
+          is_splitted: false,
+        },
+        'create',
+      );
+      fail('Expected ZodError to be thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ZodError);
+      expect((error as ZodError).issues[0].message).toBe(
+        'A data de compra deve ser menor ou igual a hoje',
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Substitui `z.coerce.date().max(new Date())` por `.refine` que avalia `new Date()` a cada validação, evitando o teto congelado no boot do processo Node.
- Adiciona testes cobrindo o cenário de processo “envelhecido” e a rejeição de datas futuras, com a mensagem `A data de compra deve ser menor ou igual a hoje`.
- Atualiza o workflow `CI Pipeline` para disparar também no evento `ready_for_review`, evitando que Unit Tests e E2E fiquem skipped ao sair de draft.

Closes #138



